### PR TITLE
Replaced deprecated `draw_glyph()`. Now using `get_glyph_shape()` instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+Below are the most important changes from each release.
+A more detailed listing of changes is available in the closed issues of the Github issue tracker (https://github.com/simoncozens/vharfbuzz/issues) and in the git commit history.
+
+
+## Upcoming release: 0.1.3 (2022-May-??)
+  - Replaced deprecated `draw_glyph()`. Now using `get_glyph_shape()` instead. (issue #4)
+
+
+## 0.1.2 (2021-Jul-12)
+  - Fixed a typo (https://github.com/simoncozens/vharfbuzz/commit/1665b992322163e77af296237084615490822f19)
+
+
+## 0.1.1 (2021-Apr-09)
+  - Allow choosing shaper (https://github.com/simoncozens/vharfbuzz/commit/ce74003ad07fb5bc1048f04f3ab56615d755f909)
+
+
+## 0.1.0 (2021-Mar-18)
+  - Initial release.

--- a/lib/vharfbuzz/__init__.py
+++ b/lib/vharfbuzz/__init__.py
@@ -180,7 +180,7 @@ class Vharfbuzz:
             buf.glyph_positions.append(pos)
         return buf
 
-    def setup_svg_draw_funcs(self):
+    def setup_svg_draw_funcs(self, container):
         if self.drawfuncs:
             return
 
@@ -202,11 +202,11 @@ class Vharfbuzz:
             c["output_string"] = c["output_string"] + "Z"
 
         self.drawfuncs = hb.DrawFuncs()
-        self.drawfuncs.set_move_to_func(move_to)
-        self.drawfuncs.set_line_to_func(line_to)
-        self.drawfuncs.set_cubic_to_func(cubic_to)
-        self.drawfuncs.set_quadratic_to_func(quadratic_to)
-        self.drawfuncs.set_close_path_func(close_path)
+        self.drawfuncs.set_move_to_func(move_to, container)
+        self.drawfuncs.set_line_to_func(line_to, container)
+        self.drawfuncs.set_cubic_to_func(cubic_to, container)
+        self.drawfuncs.set_quadratic_to_func(quadratic_to, container)
+        self.drawfuncs.set_close_path_func(close_path, container)
 
     def glyph_to_svg_path(self, gid):
         """Converts a glyph to SVG
@@ -221,9 +221,9 @@ class Vharfbuzz:
                 "glyph_to_svg_path requires uharfbuzz with draw function support"
             )
 
-        self.setup_svg_draw_funcs()
         container = {"output_string": ""}
-        self.drawfuncs.draw_glyph(self.hbfont, gid, container)
+        self.setup_svg_draw_funcs(container)
+        self.drawfuncs.get_glyph_shape(self.hbfont, gid)
         return container["output_string"]
 
     def buf_to_svg(self, buf):


### PR DESCRIPTION
(issue #4)