### PR TITLE
Draw COLRv0 layers

### DIFF
--- a/lib/vharfbuzz/__init__.py
+++ b/lib/vharfbuzz/__init__.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 __author__ = """Simon Cozens"""
 __email__ = "simon@simon-cozens.org"
-__version__ = '0.1.0'
+__version__ = "0.1.0"
 
 import uharfbuzz as hb
 import re
 
-class FakeBuffer():
+
+class FakeBuffer:
     def __init__(self):
         pass
 
-class FakeItem():
+
+class FakeItem:
     def __init__(self):
         pass
 
@@ -62,27 +64,27 @@ class Vharfbuzz:
     def shape(self, text, parameters=None, onchange=None):
         """Shapes a text
 
-    This shapes a piece of text.
+        This shapes a piece of text.
 
-    Args:
-        text (str): A string of text
-        parameters: A dictionary containing parameters to pass to Harfbuzz.
-            Relevant keys include ``script``, ``direction``, ``language``
-            (these three are normally guessed from the string contents),
-            ``features``, ``variations`` and ``shaper``.
-        onchange: An optional function with three parameters. See below.
+        Args:
+            text (str): A string of text
+            parameters: A dictionary containing parameters to pass to Harfbuzz.
+                Relevant keys include ``script``, ``direction``, ``language``
+                (these three are normally guessed from the string contents),
+                ``features``, ``variations`` and ``shaper``.
+            onchange: An optional function with three parameters. See below.
 
-    Additionally, if an `onchange` function is provided, this will be called
-    every time the buffer changes *during* shaping, with the following arguments:
+        Additionally, if an `onchange` function is provided, this will be called
+        every time the buffer changes *during* shaping, with the following arguments:
 
-    - ``self``: the vharfbuzz object.
-    - ``stage``: either "GSUB" or "GPOS"
-    - ``lookupid``: the current lookup ID
-    - ``buffer``: a copy of the buffer as a list of lists (glyphname, cluster, position)
+        - ``self``: the vharfbuzz object.
+        - ``stage``: either "GSUB" or "GPOS"
+        - ``lookupid``: the current lookup ID
+        - ``buffer``: a copy of the buffer as a list of lists (glyphname, cluster, position)
 
-    Returns:
-        A uharfbuzz ``hb.Buffer`` object
-    """
+        Returns:
+            A uharfbuzz ``hb.Buffer`` object
+        """
         if not parameters:
             parameters = {}
         hbfont = self.hbfont
@@ -138,7 +140,7 @@ class Vharfbuzz:
 
         Returns: A serialized string.
 
-       """
+        """
         hbfont = self.hbfont
         outs = []
         for info, pos in zip(buf.glyph_infos, buf.glyph_positions):
@@ -174,14 +176,16 @@ class Vharfbuzz:
         for item in s.split("|"):
             m = re.match(r"^(.*)=(\d+)(@(-?\d+),(-?\d+))?(\+(-?\d+))?$", item)
             if not m:
-                raise ValueError("Couldn't parse glyph %s in %s" % (item,s))
+                raise ValueError("Couldn't parse glyph %s in %s" % (item, s))
             groups = m.groups()
             info = FakeItem()
             info.codepoint = hbfont.glyph_from_string(groups[0])
             info.cluster = int(groups[1])
             buf.glyph_infos.append(info)
             pos = FakeItem()
-            pos.position = [ int(x or 0) for x in (groups[3], groups[4], groups[6], 0) ]  # Sorry, vertical scripts
+            pos.position = [
+                int(x or 0) for x in (groups[3], groups[4], groups[6], 0)
+            ]  # Sorry, vertical scripts
             buf.glyph_positions.append(pos)
         return buf
 

--- a/lib/vharfbuzz/__init__.py
+++ b/lib/vharfbuzz/__init__.py
@@ -260,11 +260,11 @@ class Vharfbuzz:
 
         defs = {}
         for info, pos in zip(buf.glyph_infos, buf.glyph_positions):
-            dx, dy = pos.position[0], pos.position[1]
+            dx, dy = pos.x_offset, pos.y_offset
             p = self._glyph_to_svg(info.codepoint, x_cursor + dx, y_cursor + dy, defs)
             paths.append(p)
-            x_cursor += pos.position[2]
-            y_cursor += pos.position[3]
+            x_cursor += pos.x_advance
+            y_cursor += pos.y_advance
 
         svg = [
             f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {x_cursor} {fullheight}" transform="matrix(1 0 0 -1 0 0)">',


### PR DESCRIPTION
This uses the new uharfbuzz API when available.

Supporting COLRv1 requires using the PaintFuncs, but that is more involved and I hadn’t figured out how to map PaintFuncs callbacks to SVG, so only COLRv0 is supported for now using this simpler API.