### PR TITLE
Handle the special 0xFFFF color index

### DIFF
--- a/lib/vharfbuzz/__init__.py
+++ b/lib/vharfbuzz/__init__.py
@@ -270,9 +270,12 @@ class Vharfbuzz:
             and (layers := hb.ot_color_glyph_get_layers(self.hbfont.face, gid))
         ):
             for layer in layers:
-                color = self._to_svg_color(self.palette[layer.color_index])
                 id = self._glyph_to_svg_id(layer.glyph, defs)
-                svg.append(f'<use href="#{id}" fill="{color}"/>')
+                if layer.color_index != 0xFFFF:
+                    color = self._to_svg_color(self.palette[layer.color_index])
+                    svg.append(f'<use href="#{id}" fill="{color}"/>')
+                else:
+                    svg.append(f'<use href="#{id}"/>')
         else:
             id = self._glyph_to_svg_id(gid, defs)
             svg.append(f'<use href="#{id}"/>')


### PR DESCRIPTION
Don’t set fill color in this case. Before this change code was failing with “IndexError: list index out of range”.