### PR TITLE
Allow serializing missing glyphs in buffer created by buf_from_string

### DIFF
--- a/Lib/vharfbuzz/__init__.py
+++ b/Lib/vharfbuzz/__init__.py
@@ -183,7 +183,8 @@ class Vharfbuzz:
         hbfont = self.hbfont
         outs = []
         for info, pos in zip(buf.glyph_infos, buf.glyph_positions):
-            glyphname = hbfont.glyph_to_string(info.codepoint)
+            if (glyphname := getattr(info, "name", None)) is None:
+                glyphname = hbfont.glyph_to_string(info.codepoint)
             if glyphsonly:
                 outs.append(glyphname)
                 continue
@@ -219,6 +220,9 @@ class Vharfbuzz:
             groups = m.groups()
             info = FakeItem()
             info.codepoint = hbfont.glyph_from_string(groups[0])
+            if info.codepoint is None:
+                info.codepoint = 0
+                info.name = groups[0]
             info.cluster = int(groups[1])
             buf.glyph_infos.append(info)
             pos = FakeItem()


### PR DESCRIPTION
Store the name in the FakeBuffer’s FakeItem, and use it when serializing. Make the codepoint 0 in this case to that buf_to_svg() would draw .notdef instead of crashing.

This helps with shaping tests when some glyphs in the expected output are removed from the font.